### PR TITLE
Enum search based on caption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "list-view-controls",
-  "version": "1.3.7",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-view-controls",
   "widgetName": "ListViewControls",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Search and filter Mendix list views",
   "copyright": "Mendix BV",
   "scripts": {

--- a/src/TextBoxSearch/components/TextBoxSearchContainer.ts
+++ b/src/TextBoxSearch/components/TextBoxSearchContainer.ts
@@ -123,13 +123,23 @@ export default class SearchContainer extends Component<ContainerProps, Container
             const offlineConstraints: mendix.lib.dataSource.OfflineConstraint[] = [];
             this.props.attributeList.forEach(search => {
                 if (meta.isEnum(search.attribute)) {
-                    this.matchEnumCaptions(meta, search, searchQuery)
-                        .forEach(match => offlineConstraints.push({
+                    const enumCaptionMatches = this.matchEnumCaptions(meta, search, searchQuery);
+
+                    if (enumCaptionMatches.length > 0) {
+                        enumCaptionMatches.forEach(match => offlineConstraints.push({
                             attribute: search.attribute,
                             operator: "contains",
                             path: this.props.entity,
                             value: match
                         }));
+                    } else {
+                        offlineConstraints.push({
+                            attribute: search.attribute,
+                            operator: "contains",
+                            path: this.props.entity,
+                            value: searchQuery
+                        });
+                    }
                 } else {
                     offlineConstraints.push({
                         attribute: search.attribute,
@@ -149,8 +159,13 @@ export default class SearchContainer extends Component<ContainerProps, Container
         const constraints: string[] = [];
         this.props.attributeList.forEach(searchAttribute => {
             if (meta.isEnum(searchAttribute.attribute)) {
-                this.matchEnumCaptions(meta, searchAttribute, searchQuery)
-                    .forEach(match => constraints.push(`${searchAttribute.attribute}='${match}'`));
+                const enumCaptionMatches = this.matchEnumCaptions(meta, searchAttribute, searchQuery);
+
+                if (enumCaptionMatches.length > 0) {
+                    enumCaptionMatches.forEach(match => constraints.push(`${searchAttribute.attribute}='${match}'`));
+                } else {
+                    constraints.push(`contains(${searchAttribute.attribute},'${searchQuery}')`);
+                }
             } else {
                 constraints.push(`contains(${searchAttribute.attribute},'${searchQuery}')`);
             }

--- a/src/TextBoxSearch/components/TextBoxSearchContainer.ts
+++ b/src/TextBoxSearch/components/TextBoxSearchContainer.ts
@@ -137,7 +137,7 @@ export default class SearchContainer extends Component<ContainerProps, Container
                             attribute: search.attribute,
                             operator: "contains",
                             path: this.props.entity,
-                            value: searchQuery
+                            value: " "
                         });
                     }
                 } else {
@@ -164,7 +164,7 @@ export default class SearchContainer extends Component<ContainerProps, Container
                 if (enumCaptionMatches.length > 0) {
                     enumCaptionMatches.forEach(match => constraints.push(`${searchAttribute.attribute}='${match}'`));
                 } else {
-                    constraints.push(`contains(${searchAttribute.attribute},'${searchQuery}')`);
+                    constraints.push(`contains(${searchAttribute.attribute}," ")`);
                 }
             } else {
                 constraints.push(`contains(${searchAttribute.attribute},'${searchQuery}')`);

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ListViewControls" version="1.3.8" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ListViewControls" version="1.3.9" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CheckBoxFilter/CheckBoxFilter.xml"/>
             <widgetFile path="DropDownFilter/DropDownFilter.xml"/>


### PR DESCRIPTION
When using the Text Box Search widget on an enumeration attribute it now searches correctly on the caption instead of the enumeration database key value. (Solves GitHub issue #74)