### PR TITLE
Fix/sorting after page close

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "raw-loader": "^4.0.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-hot-loader": "^4.12.19",
     "react-test-renderer": "^16.8.4",
     "remap-istanbul": "^0.13.0",
     "sass-loader": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-view-controls",
   "widgetName": "ListViewControls",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Search and filter Mendix list views",
   "copyright": "Mendix BV",
   "scripts": {

--- a/src/Pagination/components/PaginationContainer.ts
+++ b/src/Pagination/components/PaginationContainer.ts
@@ -1,5 +1,4 @@
 import { Component, ReactChild, ReactNode, createElement } from "react";
-import { hot } from "react-hot-loader";
 
 import * as classNames from "classnames";
 import * as dojoAspect from "dojo/aspect";
@@ -11,8 +10,12 @@ import { DataSourceHelper, DataSourceHelperListView } from "../../Shared/DataSou
 
 import {
     getTranslations,
-    hideLoadMoreButton, mxTranslation, persistListViewHeight,
-    resetListViewHeight, setListNodeToEmpty, showLoadMoreButton
+    hideLoadMoreButton,
+    mxTranslation,
+    persistListViewHeight,
+    resetListViewHeight,
+    setListNodeToEmpty,
+    showLoadMoreButton
 } from "../utils/ContainerUtils";
 
 import { ModelerProps } from "../Pagination";
@@ -281,4 +284,4 @@ class PaginationContainer extends Component<ModelerProps, PaginationContainerSta
 
 }
 
-export default hot(module)(PaginationContainer);
+export default PaginationContainer;

--- a/src/Shared/DataSourceHelper/DataSourceHelper.ts
+++ b/src/Shared/DataSourceHelper/DataSourceHelper.ts
@@ -47,7 +47,8 @@ export class DataSourceHelper {
         aspect.after(widget, "storeState", (store: (key: string, value: any) => void) => {
             logger.debug("after storeState");
             if (widget.__customWidgetDataSourceHelper) {
-                store("lvcSorting", widget.__customWidgetDataSourceHelper.sorting);
+                const sorting = widget.__customWidgetDataSourceHelper.sorting && widget.__customWidgetDataSourceHelper.originalSort;
+                store("lvcSorting", sorting);
                 store("lvcConstraints", widget.__customWidgetDataSourceHelper.constraints);
                 store("lvcPaging", widget.__customWidgetDataSourceHelper.paging);
             }

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ListViewControls" version="1.3.9" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ListViewControls" version="1.3.10" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CheckBoxFilter/CheckBoxFilter.xml"/>
             <widgetFile path="DropDownFilter/DropDownFilter.xml"/>


### PR DESCRIPTION
- We fixed an issue where pagination widget would change the corresponding listview's ordering in a particular scenario.
(Fixes ticket 113097)