### PR TITLE
[WC-386]: include the previous constraints when setting new ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-view-controls",
   "widgetName": "ListViewControls",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Search and filter Mendix list views",
   "copyright": "Mendix BV",
   "scripts": {

--- a/src/Shared/DataSourceHelper/DataSourceHelper.ts
+++ b/src/Shared/DataSourceHelper/DataSourceHelper.ts
@@ -125,7 +125,7 @@ export class DataSourceHelper {
     }
 
     private updateDataSource(callback: () => void, restoreState: boolean) {
-        let constraints: Constraints = [];
+        let constraints: Constraints;
         let sorting: string[][] = Object.keys(this.store.sorting)
             .map(key => this.store.sorting[key])
             .filter(sortConstraint => sortConstraint[0] && sortConstraint[1]);
@@ -161,6 +161,7 @@ export class DataSourceHelper {
                 }
             }
 
+            // TODO: Since we do not include `this.widget_datasource._constraints` here, this can cause filtering to reset all the constraints.
             constraints = [ ...unGroupedConstraints, ...unGroupedOrConstraints, ...groupedConstraints ];
 
         } else {
@@ -178,7 +179,7 @@ export class DataSourceHelper {
                 .join("")
                 .replace(/\[]/g, ""); // Remove empty string "[]"
 
-            constraints = unGroupedConstraints + groupedConstraints;
+            constraints = this.widget._datasource._constraints + unGroupedConstraints + groupedConstraints;
             // if (!restoreState) {
             //     this.widget._datasource._sorting = sorting;
             // }

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ListViewControls" version="1.3.10" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ListViewControls" version="1.3.11" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CheckBoxFilter/CheckBoxFilter.xml"/>
             <widgetFile path="DropDownFilter/DropDownFilter.xml"/>


### PR DESCRIPTION
Now when a change happens, we also include the previous set contraints when updating them.

TODO: When online, we work with strings so fixing it can just be done by concatenation. But when offline, it's a completely different story that is slightly harder to address. It's also part of the hybrid profiles, which is something we do not support anymore. For now we fix it for online first.

cc @diego-antonelli 