### PR TITLE
[WC-509] Construct internal constraints list view widget separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this tool will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 1.3.12 - 2021-05-27
+
+### Fixed
+
+-   Fixed an issue introduced in v1.3.11 where using a list view control widget multiple times would accumulate its constraints instead of replacing them.
+-   Fixed an issue where the list view control widgets constraints are combined incorrectly with the integrated list view search's constraints, losing context in-between.
+
+## 1.3.11 - 2021-05-10 [YANKED]
+
+### Fixed
+
+-   Fixed an issue where combining list view filtering with pagination sort would reset all the filters. (Fixes Ticket #119143)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "list-view-controls",
-  "version": "1.3.9",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3625,12 +3625,6 @@
         "entities": "^1.1.1"
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -5056,16 +5050,6 @@
         }
       }
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -5744,15 +5728,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.7.0"
       }
     },
     "homedir-polyfill": {
@@ -8385,15 +8360,6 @@
       "dev": true,
       "optional": true
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10203,40 +10169,10 @@
         "scheduler": "^0.13.4"
       }
     },
-    "react-hot-loader": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.19.tgz",
-      "integrity": "sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==",
-      "dev": true,
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-      "dev": true
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
     "react-test-renderer": {
@@ -11263,12 +11199,6 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-view-controls",
   "widgetName": "ListViewControls",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Search and filter Mendix list views",
   "copyright": "Mendix BV",
   "scripts": {

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ListViewControls" version="1.3.11" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ListViewControls" version="1.3.12" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CheckBoxFilter/CheckBoxFilter.xml"/>
             <widgetFile path="DropDownFilter/DropDownFilter.xml"/>


### PR DESCRIPTION
Due to our previous fix in https://github.com/mendix/list-view-controls/pull/89, we would always use the previous constraints when constructing the new ones. This seemed to have fixed the issue of separate control widgets fighting for control over the list view by making their constraints accumulate. 

But this introduced another major bug where using the same control widget more than once would also accumulate the constraints from that same widget. So if the dropdown filter was used twice, first with "Value A" and then "Value B", then the resulting constraints would be to filter for both "Value A" **and** "Value B". This is obviously not what we want.

Initial idea was to parse all the constraints (previous, ungrouped, and grouped), stack them together and filter out the similar ones. But the problem with this is that **different** control widgets can apply constraints on the same attribute and that should result in a "and"-concat. The main thing is that we need to know which constraints are applied by what control widget.

![image](https://user-images.githubusercontent.com/5955441/118944174-9ac62380-b954-11eb-8359-dbe631657bfb.png)

For grouped and ungrouped we already know that, since the existing code already implemented that. But for the built-in control widget for list view, which should only be search ❓ , we lose that context in our current implementation. Unfortunately there is no easy function we can call that will immediately provide us with the constraints for the list view widget. But there is code, in one of the function (`QuerySource`) so I copied that into this project.

Now it will always do the following:
- Get the constraints from the list view specifically (search).
- Get all the grouped constraints from control widgets.
- Get all the ungrouped constraints from control widgets.
- Then combine everything and apply those constraints to the list view.


## Testing Instructions
@leonardomendix can you make sure that neither the bgu reported in WC-509 as well as WC-386 is not reproducible anymore? Please use a list view with a bit more data and play around with _at least_ the built-in search and a dropdown filter. Potentially also add other LVC widgets.
 