### PR TITLE
[WC-530] only retrieve the search text if search is enabled to prevent error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## 1.3.12 - 2021-05-27
+### Fixed
+
+-   Fixed an issue introduced in v1.3.12 where if the list view's search is not enabled, then the widget would error on any list view control widget interaction.  
+
+## 1.3.12 - 2021-05-27 [YANKED]
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "list-view-controls",
   "widgetName": "ListViewControls",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Search and filter Mendix list views",
   "copyright": "Mendix BV",
   "scripts": {

--- a/src/Shared/DataSourceHelper/DataSourceHelper.ts
+++ b/src/Shared/DataSourceHelper/DataSourceHelper.ts
@@ -26,6 +26,7 @@ export interface DataSourceHelperListView extends mxui.widget.ListView {
     __customWidgetPagingLoading: boolean;
     __customWidgetPagingOffset: number;
     _getSearchText?: () => string;
+    hasSearch: boolean;
 }
 
 export class DataSourceHelper {
@@ -182,7 +183,8 @@ export class DataSourceHelper {
 
             // @ts-ignore This is a subclass property, but we also handle it gracefully if not present.
             const searchPaths: string[] | undefined = this.widget._datasource._searchPaths;
-            const searchText: string | undefined = this.widget._getSearchText?.();
+            // If there is no search, trying to get it will error so first check whether search is enabled.
+            const searchText: string | undefined = this.widget.hasSearch ? this.widget._getSearchText?.() : undefined;
 
             // Unfortunately the listview datasource object does not have a `_getSearchConstraints()` function of some kind,
             // but rather builds it on the fly in `setSearchText(string)`. To not affect the ListView widget, we copy that part

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ListViewControls" version="1.3.12" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ListViewControls" version="1.3.13" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CheckBoxFilter/CheckBoxFilter.xml"/>
             <widgetFile path="DropDownFilter/DropDownFilter.xml"/>


### PR DESCRIPTION
Bug caused by https://github.com/mendix/list-view-controls/pull/95: internally the function `_getSearchText` will error out if there is no search enabled on the list view widget. I expected it to return an empty result instead. So now we first check whether the list view widget has search enabled, then retrieve it, otherwise return `undefined`.

@leonardomendix please make sure to use the e2e specs that we discussed for testing this before releasing v.1.3.13